### PR TITLE
Add information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# Download [here](https://github.com/jojoe77777/Toolscreen/releases)
+# Toolscreen
+
+A Minecraft speedrunning tool for resizing, overlays resizing and more without requiring OBS projectors or leaving fullscreen mode!
+
+Toolscreen is fully legal to use in Minecraft speedruns on [speedrun.com](https://www.speedrun.com/mc) and [MCSR Ranked](https://mcsrranked.com/)
+
+## [Download](https://github.com/jojoe77777/Toolscreen/releases/latest)
+
+You can download Toolscreen from the [releases page](https://github.com/jojoe77777/Toolscreen/releases/latest). 
+The file you need to download is named like `Toolscreen-X.X.X-double-click-me.jar `
+
+## Installing
+
+> If you don't like to read, check out the [video guide](https://www.youtube.com/watch?v=YqS-fxPx_jo)
+
+1. Download the [latest release](https://github.com/jojoe77777/Toolscreen/releases/latest)
+2. Locate your instance folder (MultiMC: right click instance > "Instance Folder", Prism Launcher: right click instance > "Folder")
+3. Copy the downloaded file into the instance folder and double click it to run, following the on-screen instructions
+4. Launch Minecraft like you normally would and check for the Toolscreen popup in the top left
+
+## Configuration & Usage
+
+To configure Toolscreen, press <kbd>CTRL</kbd> + <kbd>I</kbd>.
+You can toggle between Basic and Advanced Mode.
+Basic Mode contains the most commonly used features, while Advanced Mode contains all features.
+Toolscreen comes pre-configured, so you will likely not need to change most of the settings.
+
+To check what a configuration does, hover over the `(?)` icon next to it for a tooltip.
+
+## Compatibility
+Toolscreen works on any **Windows 10/11** device, excluding ARM64 devices.


### PR DESCRIPTION
Adds basic information about Toolscreen to the README. Previously, it only had a download link, which seems unprofessional and also kind of sketchy.