### PR TITLE
feat: add auto-borderless mode

### DIFF
--- a/src/config_defaults.h
+++ b/src/config_defaults.h
@@ -254,6 +254,7 @@ inline std::vector<DWORD> GetDefaultGuiHotkey() { return { VK_LCONTROL, 'I' }; }
 
 // Default borderless toggle hotkey: unbound/disabled
 inline std::vector<DWORD> GetDefaultBorderlessHotkey() { return {}; }
+constexpr bool CONFIG_AUTO_BORDERLESS = false;
 
 // Default overlay visibility toggle hotkeys: unbound/disabled
 inline std::vector<DWORD> GetDefaultImageOverlaysHotkey() { return {}; }

--- a/src/config_toml.cpp
+++ b/src/config_toml.cpp
@@ -1462,6 +1462,7 @@ void ConfigToToml(const Config& config, toml::table& out) {
     toml::array borderlessHotkeyArr;
     for (const auto& key : config.borderlessHotkey) { borderlessHotkeyArr.push_back(static_cast<int64_t>(key)); }
     out.insert("borderlessHotkey", borderlessHotkeyArr);
+    out.insert("autoBorderless", config.autoBorderless);
 
     // Overlay visibility toggle hotkeys (optional)
     toml::array imageOverlaysHotkeyArr;
@@ -1601,6 +1602,7 @@ void ConfigFromToml(const toml::table& tbl, Config& config) {
         }
     }
     if (!hasBorderlessHotkey) { config.borderlessHotkey = ConfigDefaults::GetDefaultBorderlessHotkey(); }
+    config.autoBorderless = GetOr(tbl, "autoBorderless", ConfigDefaults::CONFIG_AUTO_BORDERLESS);
 
     // Overlay visibility toggle hotkeys (optional; empty array = disabled)
     config.imageOverlaysHotkey.clear();
@@ -1756,6 +1758,7 @@ bool SaveConfigToTomlFile(const Config& config, const std::wstring& path) {
                                                  "disableConfigurePrompt",
                                                  "guiHotkey",
                                                  "borderlessHotkey",
+                                                 "autoBorderless",
                                                  "imageOverlaysHotkey",
                                                  "windowOverlaysHotkey",
                                                  "debug",

--- a/src/gui.h
+++ b/src/gui.h
@@ -467,6 +467,7 @@ struct Config {
     // Hotkey to toggle borderless-windowed fullscreen for the game window.
     // Empty = disabled/unbound.
     std::vector<DWORD> borderlessHotkey = {};
+    bool autoBorderless = false;
     // Hotkeys to toggle overlay visibility (runtime only; does not change mode config).
     // Empty = disabled/unbound.
     std::vector<DWORD> imageOverlaysHotkey = {};

--- a/src/gui/tab_basic_other.inl
+++ b/src/gui/tab_basic_other.inl
@@ -109,6 +109,21 @@ if (ImGui::BeginTabItem("Other")) {
     HelpMarker("Toggles the game window between its previous windowed size and a borderless, monitor-sized window.");
     ImGui::PopID();
 
+    // Auto-Borderless toggle
+    {
+        ImGui::PushID("basic_auto_borderless");
+        ImGui::Text("Auto-Borderless:");
+        ImGui::SameLine();
+        const char* label = g_config.autoBorderless ? "Enabled" : "Disabled";
+        if (ImGui::Button(label, ImVec2(150, 0))) {
+            g_config.autoBorderless = !g_config.autoBorderless;
+            g_configIsDirty = true;
+        }
+        ImGui::SameLine();
+        HelpMarker("Automatically puts Minecraft in borderless mode when the window is detected on startup.");
+        ImGui::PopID();
+    }
+
     // --- DISPLAY SETTINGS ---
     ImGui::SeparatorText("Display Settings");
 

--- a/src/logic_thread.cpp
+++ b/src/logic_thread.cpp
@@ -524,6 +524,21 @@ void CheckGameStateReset() {
     s_previousGameStateForReset = localGameState;
 }
 
+static void CheckAutoBorderless() {
+    static bool s_checked = false;
+    if (s_checked) { return; }
+
+    HWND hwnd = g_minecraftHwnd.load(std::memory_order_relaxed);
+    if (!hwnd) { return; }
+
+    s_checked = true;
+
+    if (!g_config.autoBorderless) { return; }
+
+    ToggleBorderlessWindowedFullscreen(hwnd);
+    Log("[LogicThread] Auto-borderless applied");
+}
+
 static void LogicThreadFunc() {
     LogCategory("init", "[LogicThread] Started");
 
@@ -556,6 +571,7 @@ static void LogicThreadFunc() {
         ProcessPendingModeSwitch();
         ProcessPendingDimensionChange();
         CheckGameStateReset();
+        CheckAutoBorderless();
 
         // Sleep for remaining time in tick
         auto tickEnd = std::chrono::steady_clock::now();


### PR DESCRIPTION
switch in the GUI: when enabled, toolscreen will enter borderless mode as soon as the game window is detected