### PR TITLE
feat: hotkey conflict prevention

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2717,7 +2717,30 @@ void RenderSettingsGUI() {
         static uint64_t s_lastBindingInputSeqHotkeyBind = 0;
         if (ImGui::IsWindowAppearing()) { s_lastBindingInputSeqHotkeyBind = GetLatestBindingInputSequence(); }
 
+        static std::string s_hotkeyConflictMessage;
+
         auto finalize_bind = [&](const std::vector<DWORD>& keys) {
+            if (!keys.empty() && s_exclusionToBind.hotkey_idx == -1) {
+                std::string excludeLabel;
+                if (s_mainHotkeyToBind == -999) excludeLabel = "GUI Toggle";
+                else if (s_mainHotkeyToBind == -998) excludeLabel = "Borderless Toggle";
+                else if (s_mainHotkeyToBind == -997) excludeLabel = "Image Overlays Toggle";
+                else if (s_mainHotkeyToBind == -996) excludeLabel = "Window Overlays Toggle";
+                else if (s_mainHotkeyToBind == -995) excludeLabel = "Key Rebinds Toggle";
+                else if (s_mainHotkeyToBind >= 0) excludeLabel = "Mode Hotkey #" + std::to_string(s_mainHotkeyToBind + 1);
+                else if (s_sensHotkeyToBind != -1) excludeLabel = "Sensitivity Hotkey #" + std::to_string(s_sensHotkeyToBind + 1);
+                else if (s_altHotkeyToBind.hotkey_idx != -1) excludeLabel = "Mode Hotkey #" + std::to_string(s_altHotkeyToBind.hotkey_idx + 1) + " Alt #" + std::to_string(s_altHotkeyToBind.alt_idx + 1);
+
+                std::string conflict = FindHotkeyConflict(keys, excludeLabel);
+                if (!conflict.empty()) {
+                    s_hotkeyConflictMessage = "Already assigned to " + conflict;
+                    s_bindingKeys.clear();
+                    s_hadKeysPressed = false;
+                    return;
+                }
+            }
+            s_hotkeyConflictMessage.clear();
+
             if (s_mainHotkeyToBind != -1) {
                 if (s_mainHotkeyToBind == -999) {
                     g_config.guiHotkey = keys;
@@ -2875,13 +2898,17 @@ void RenderSettingsGUI() {
             }
         }
 
-        if (!currentlyPressed.empty()) { s_hadKeysPressed = true; }
+        if (!currentlyPressed.empty()) {
+            if (!s_hadKeysPressed) s_hotkeyConflictMessage.clear();
+            s_hadKeysPressed = true;
+        }
 
-        // If we had keys pressed and now all are released, finalize the binding
         if (s_hadKeysPressed && currentlyPressed.empty()) {
             finalize_bind(s_bindingKeys);
-            ImGui::EndPopup();
-            return;
+            if (s_hotkeyConflictMessage.empty()) {
+                ImGui::EndPopup();
+                return;
+            }
         }
 
         if (!s_bindingKeys.empty()) {
@@ -2890,6 +2917,9 @@ void RenderSettingsGUI() {
         } else {
             ImGui::Text("Current: [None]");
         }
+
+        if (!s_hotkeyConflictMessage.empty())
+            ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "%s", s_hotkeyConflictMessage.c_str());
 
         ImGui::EndPopup();
     }

--- a/src/gui/tab_hotkeys.inl
+++ b/src/gui/tab_hotkeys.inl
@@ -244,6 +244,7 @@ if (IsResolutionChangeSupported(g_gameVersion)) {
                 }
                 if (alt_to_remove != -1) {
                     hotkey.altSecondaryModes.erase(hotkey.altSecondaryModes.begin() + alt_to_remove);
+                    SetHotkeySecondaryMode(i, hotkey.secondaryMode);
                     g_configIsDirty = true;
                 }
                 if (ImGui::Button("Add Alternative Mode")) {

--- a/src/input_hook.cpp
+++ b/src/input_hook.cpp
@@ -56,6 +56,7 @@ extern std::mutex g_triggerOnReleaseMutex;
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 static bool s_forcedShowCursor = false;
+static size_t s_bestMatchKeyCount = 0;
 
 static void EnsureSystemCursorVisible() {
     if (g_gameVersion < GameVersion(1, 13, 0)) { return; }
@@ -438,7 +439,7 @@ InputHandlerResult HandleGuiToggle(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         return { false, 0 };
     }
 
-    if (!isEscape && !CheckHotkeyMatch(g_config.guiHotkey, vkCode)) { return { false, 0 }; }
+    if (!isEscape && !CheckHotkeyMatch(g_config.guiHotkey, vkCode, {}, false, s_bestMatchKeyCount)) { return { false, 0 }; }
 
     if (g_showGui.load(std::memory_order_acquire) && !isEscape) {
         switch (uMsg) {
@@ -592,7 +593,7 @@ InputHandlerResult HandleBorderlessToggle(HWND hWnd, UINT uMsg, WPARAM wParam, L
         return { false, 0 };
     }
 
-    if (!CheckHotkeyMatch(g_config.borderlessHotkey, vkCode)) { return { false, 0 }; }
+    if (!CheckHotkeyMatch(g_config.borderlessHotkey, vkCode, {}, false, s_bestMatchKeyCount)) { return { false, 0 }; }
 
     static std::atomic<int64_t> s_lastToggleMs{ 0 };
     auto now = std::chrono::steady_clock::now();
@@ -649,7 +650,7 @@ InputHandlerResult HandleImageOverlaysToggle(HWND hWnd, UINT uMsg, WPARAM wParam
         return { false, 0 };
     }
 
-    if (!CheckHotkeyMatch(g_config.imageOverlaysHotkey, vkCode)) { return { false, 0 }; }
+    if (!CheckHotkeyMatch(g_config.imageOverlaysHotkey, vkCode, {}, false, s_bestMatchKeyCount)) { return { false, 0 }; }
 
     static std::atomic<int64_t> s_lastToggleMs{ 0 };
     auto now = std::chrono::steady_clock::now();
@@ -708,7 +709,7 @@ InputHandlerResult HandleWindowOverlaysToggle(HWND hWnd, UINT uMsg, WPARAM wPara
         return { false, 0 };
     }
 
-    if (!CheckHotkeyMatch(g_config.windowOverlaysHotkey, vkCode)) { return { false, 0 }; }
+    if (!CheckHotkeyMatch(g_config.windowOverlaysHotkey, vkCode, {}, false, s_bestMatchKeyCount)) { return { false, 0 }; }
 
     static std::atomic<int64_t> s_lastToggleMs{ 0 };
     auto now = std::chrono::steady_clock::now();
@@ -771,7 +772,7 @@ InputHandlerResult HandleKeyRebindsToggle(HWND hWnd, UINT uMsg, WPARAM wParam, L
         return { false, 0 };
     }
 
-    if (!CheckHotkeyMatch(g_config.keyRebinds.toggleHotkey, vkCode)) { return { false, 0 }; }
+    if (!CheckHotkeyMatch(g_config.keyRebinds.toggleHotkey, vkCode, {}, false, s_bestMatchKeyCount)) { return { false, 0 }; }
 
     static std::atomic<int64_t> s_lastToggleMs{ 0 };
     auto now = std::chrono::steady_clock::now();
@@ -1153,10 +1154,9 @@ InputHandlerResult HandleHotkeys(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
         }
 
         for (const auto& alt : hotkey.altSecondaryModes) {
-            bool matched = CheckHotkeyMatch(alt.keys, vkCode, hotkey.conditions.exclusions, hotkey.triggerOnRelease);
-            bool matchedViaRebind = !matched && rebindTargetVk && CheckHotkeyMatch(alt.keys, rebindTargetVk, hotkey.conditions.exclusions, hotkey.triggerOnRelease);
+            bool matched = CheckHotkeyMatch(alt.keys, vkCode, hotkey.conditions.exclusions, hotkey.triggerOnRelease, s_bestMatchKeyCount);
+            bool matchedViaRebind = !matched && rebindTargetVk && CheckHotkeyMatch(alt.keys, rebindTargetVk, hotkey.conditions.exclusions, hotkey.triggerOnRelease, s_bestMatchKeyCount);
             if (matched || matchedViaRebind) {
-                // When matched via rebind target, always block original key from game
                 bool blockKey = hotkey.blockKeyFromGame || matchedViaRebind;
                 std::string hotkeyId = GetKeyComboString(alt.keys);
 
@@ -1224,14 +1224,12 @@ InputHandlerResult HandleHotkeys(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
         }
 
         {
-            bool matched = CheckHotkeyMatch(hotkey.keys, vkCode, hotkey.conditions.exclusions, hotkey.triggerOnRelease);
-            bool matchedViaRebind = !matched && rebindTargetVk && CheckHotkeyMatch(hotkey.keys, rebindTargetVk, hotkey.conditions.exclusions, hotkey.triggerOnRelease);
+            bool matched = CheckHotkeyMatch(hotkey.keys, vkCode, hotkey.conditions.exclusions, hotkey.triggerOnRelease, s_bestMatchKeyCount);
+            bool matchedViaRebind = !matched && rebindTargetVk && CheckHotkeyMatch(hotkey.keys, rebindTargetVk, hotkey.conditions.exclusions, hotkey.triggerOnRelease, s_bestMatchKeyCount);
             if (matched || matchedViaRebind) {
-                // When matched via rebind target, always block original key from game
                 bool blockKey = hotkey.blockKeyFromGame || matchedViaRebind;
                 std::string hotkeyId = GetKeyComboString(hotkey.keys);
 
-                // Handle trigger-on-release invalidation tracking
                 if (hotkey.triggerOnRelease) {
                     if (isKeyDown) {
                         std::lock_guard<std::mutex> lock(g_triggerOnReleaseMutex);
@@ -1329,10 +1327,9 @@ InputHandlerResult HandleHotkeys(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
         if (!isKeyDown) { continue; }
 
         {
-            bool matched = CheckHotkeyMatch(sensHotkey.keys, vkCode, sensHotkey.conditions.exclusions, false);
-            bool matchedViaRebind = !matched && rebindTargetVk && CheckHotkeyMatch(sensHotkey.keys, rebindTargetVk, sensHotkey.conditions.exclusions, false);
+            bool matched = CheckHotkeyMatch(sensHotkey.keys, vkCode, sensHotkey.conditions.exclusions, false, s_bestMatchKeyCount);
+            bool matchedViaRebind = !matched && rebindTargetVk && CheckHotkeyMatch(sensHotkey.keys, rebindTargetVk, sensHotkey.conditions.exclusions, false, s_bestMatchKeyCount);
             if (matched || matchedViaRebind) {
-                // Sensitivity hotkeys have no blockKeyFromGame setting; only block when matched via rebind
                 bool blockKey = matchedViaRebind;
                 std::string hotkeyId = "sens_" + GetKeyComboString(sensHotkey.keys);
 
@@ -2147,6 +2144,50 @@ InputHandlerResult HandleCharRebinding(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
     return { false, 0 };
 }
 
+static void ResolveHotkeyPriority(UINT uMsg, WPARAM wParam, LPARAM lParam) {
+    s_bestMatchKeyCount = 0;
+
+    DWORD vkCode = 0;
+    switch (uMsg) {
+    case WM_KEYDOWN:
+    case WM_SYSKEYDOWN:
+        vkCode = NormalizeModifierVkFromKeyMessage(static_cast<DWORD>(wParam), lParam);
+        break;
+    case WM_LBUTTONDOWN: vkCode = VK_LBUTTON; break;
+    case WM_RBUTTONDOWN: vkCode = VK_RBUTTON; break;
+    case WM_MBUTTONDOWN: vkCode = VK_MBUTTON; break;
+    case WM_XBUTTONDOWN:
+        vkCode = (GET_XBUTTON_WPARAM(wParam) == XBUTTON1) ? VK_XBUTTON1 : VK_XBUTTON2;
+        break;
+    default: return;
+    }
+
+    { // Skip resolution entirely for keys that aren't bound to any hotkey
+        std::lock_guard<std::mutex> lock(g_hotkeyMainKeysMutex);
+        if (g_hotkeyMainKeys.find(vkCode) == g_hotkeyMainKeys.end()) return;
+    }
+
+    auto check = [&](const std::vector<DWORD>& keys, const std::vector<DWORD>& exclusions = {}) {
+        if (!keys.empty() && CheckHotkeyMatch(keys, vkCode, exclusions, false))
+            s_bestMatchKeyCount = (std::max)(s_bestMatchKeyCount, keys.size());
+    };
+
+    check(g_config.guiHotkey);
+    check(g_config.borderlessHotkey);
+    check(g_config.imageOverlaysHotkey);
+    check(g_config.windowOverlaysHotkey);
+    check(g_config.keyRebinds.toggleHotkey);
+
+    for (const auto& hk : g_config.hotkeys) {
+        check(hk.keys, hk.conditions.exclusions);
+        for (const auto& alt : hk.altSecondaryModes)
+            check(alt.keys, hk.conditions.exclusions);
+    }
+
+    for (const auto& sh : g_config.sensitivityHotkeys)
+        check(sh.keys, sh.conditions.exclusions);
+}
+
 LRESULT CALLBACK SubclassedWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     PROFILE_SCOPE("SubclassedWndProc");
 
@@ -2182,6 +2223,8 @@ LRESULT CALLBACK SubclassedWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
 
     result = HandleToolscreenQueryMessages(hWnd, uMsg, wParam, lParam);
     if (result.consumed) return result.result;
+
+    ResolveHotkeyPriority(uMsg, wParam, lParam);
 
     result = HandleBorderlessToggle(hWnd, uMsg, wParam, lParam);
     if (result.consumed) return result.result;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1660,9 +1660,10 @@ DWORD WINAPI ImageMonitorThread(LPVOID lpParam) {
     }
 }
 
-bool CheckHotkeyMatch(const std::vector<DWORD>& keys, WPARAM wParam, const std::vector<DWORD>& exclusionKeys, bool triggerOnRelease) {
+bool CheckHotkeyMatch(const std::vector<DWORD>& keys, WPARAM wParam, const std::vector<DWORD>& exclusionKeys, bool triggerOnRelease, size_t minKeyCount) {
     PROFILE_SCOPE_CAT("Hotkey Match Check", "Game Logic");
     if (keys.empty()) return false;
+    if (keys.size() < minKeyCount) return false;
 
     auto isModifierKey = [](DWORD key) {
         return key == VK_CONTROL || key == VK_LCONTROL || key == VK_RCONTROL || key == VK_SHIFT || key == VK_LSHIFT || key == VK_RSHIFT ||
@@ -1886,6 +1887,66 @@ bool CheckHotkeyMatch(const std::vector<DWORD>& keys, WPARAM wParam, const std::
     }
 
     return true;
+}
+
+static std::vector<DWORD> NormalizeKeysForComparison(const std::vector<DWORD>& keys) {
+    if (keys.empty()) return {};
+
+    auto normalizeModifier = [](DWORD k) -> DWORD {
+        if (k == VK_LCONTROL || k == VK_RCONTROL) return VK_CONTROL;
+        if (k == VK_LSHIFT || k == VK_RSHIFT) return VK_SHIFT;
+        if (k == VK_LMENU || k == VK_RMENU) return VK_MENU;
+        return k;
+    };
+
+    std::vector<DWORD> result;
+    result.reserve(keys.size());
+    for (size_t i = 0; i + 1 < keys.size(); ++i)
+        result.push_back(normalizeModifier(keys[i]));
+    std::sort(result.begin(), result.end());
+    result.push_back(normalizeModifier(keys.back()));
+    return result;
+}
+
+std::string FindHotkeyConflict(const std::vector<DWORD>& newKeys, const std::string& excludeLabel) {
+    if (newKeys.empty()) return "";
+
+    struct Entry {
+        const std::vector<DWORD>* keys;
+        std::string label;
+    };
+
+    std::vector<Entry> all;
+
+    auto add = [&](const std::vector<DWORD>& k, std::string lbl) {
+        if (!k.empty()) all.push_back({ &k, std::move(lbl) });
+    };
+
+    add(g_config.guiHotkey, "GUI Toggle");
+    add(g_config.borderlessHotkey, "Borderless Toggle");
+    add(g_config.imageOverlaysHotkey, "Image Overlays Toggle");
+    add(g_config.windowOverlaysHotkey, "Window Overlays Toggle");
+    add(g_config.keyRebinds.toggleHotkey, "Key Rebinds Toggle");
+
+    for (size_t i = 0; i < g_config.hotkeys.size(); ++i) {
+        const auto& hk = g_config.hotkeys[i];
+        add(hk.keys, "Mode Hotkey #" + std::to_string(i + 1));
+        for (size_t j = 0; j < hk.altSecondaryModes.size(); ++j)
+            add(hk.altSecondaryModes[j].keys, "Mode Hotkey #" + std::to_string(i + 1) + " Alt #" + std::to_string(j + 1));
+    }
+
+    for (size_t i = 0; i < g_config.sensitivityHotkeys.size(); ++i)
+        add(g_config.sensitivityHotkeys[i].keys, "Sensitivity Hotkey #" + std::to_string(i + 1));
+
+    auto normalized = NormalizeKeysForComparison(newKeys);
+
+    for (const auto& entry : all) {
+        if (entry.label == excludeLabel) continue;
+        if (NormalizeKeysForComparison(*entry.keys) == normalized)
+            return entry.label;
+    }
+
+    return "";
 }
 
 void GetRelativeCoords(const std::string& type, int relX, int relY, int w, int h, int containerW, int containerH, int& outX, int& outY) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -352,7 +352,9 @@ void LoadImageAsync(DecodedImageData::Type type, std::string id, std::string pat
 void LoadAllImages();
 
 bool CheckHotkeyMatch(const std::vector<DWORD>& keys, WPARAM wParam, const std::vector<DWORD>& exclusionKeys = {},
-                      bool triggerOnRelease = false);
+                      bool triggerOnRelease = false, size_t minKeyCount = 0);
+
+std::string FindHotkeyConflict(const std::vector<DWORD>& newKeys, const std::string& excludeLabel);
 
 void BackupConfigFile();
 


### PR DESCRIPTION
- Prevent duplicate hotkey bindings with a warning when the combo is already in use
- More-specific combos take priority over broader ones (Ctrl+I wins over bare I)                                                                                                                                           - Fix alt secondary mode deletion getting stuck when no mode was assigned